### PR TITLE
Fix adapter-static build failure for dynamic routes

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,9 +8,9 @@ const config = {
 		adapter: adapter({
 			pages: 'build',
 			assets: 'build',
-			fallback: undefined,
+			fallback: '404.html',
 			precompress: false,
-			strict: true
+			strict: false
 		})
 	}
 };


### PR DESCRIPTION
@cerisyl 

Set strict: false and add 404.html fallback so the [slug] API routes don't break the static build. These routes are client-rendered and don't need prerendering.